### PR TITLE
macroを使ったTransformインスタンスの定義

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,3 +3,8 @@ name := "ExtensibleException"
 version := "1.0"
 
 scalaVersion := "2.11.7"
+
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
+)
+

--- a/src/main/scala/utils/Exceptions.scala
+++ b/src/main/scala/utils/Exceptions.scala
@@ -24,3 +24,11 @@ trait FileException extends RootException
 case class ReadException(m: String) extends FileException
 
 case class WriteException(m: String) extends FileException
+
+// defined by macro
+case class FileAndHttpException(cause: Throwable) extends RootException
+object FileAndHttpException {
+  implicit val fileException = Transform.castable[FileException, FileAndHttpException]
+  implicit val httpException = Transform.castable[HttpException, FileAndHttpException]
+}
+

--- a/src/main/scala/utils/Transform.scala
+++ b/src/main/scala/utils/Transform.scala
@@ -1,4 +1,6 @@
 package utils
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
 
 trait :->[-A, +B] {
   def cast(a: A): B
@@ -7,6 +9,21 @@ trait :->[-A, +B] {
 object :-> {
   implicit def superclass[A, B >: A] = new :->[A, B] {
     def cast(a: A): B = a
+  }
+}
+
+object Transform {
+  def castable[A, B]: A :-> B = macro castableImpl[A, B]
+
+  def castableImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: Context): c.Expr[A :-> B] = {
+    import c.universe._
+
+    val fromClassSym = c.weakTypeOf[A].typeSymbol
+    val toClassSym = c.weakTypeOf[B].typeSymbol
+
+    c.Expr[A :-> B](q"""new :->[$fromClassSym, $toClassSym] {
+      def cast(a: $fromClassSym): $toClassSym = ${toClassSym.companion}.apply(a)
+      }""")
   }
 }
 


### PR DESCRIPTION
以下のように`:->`のインスタンス定義の際に生じるボイラープレートを排除するマクロを作りました。

`FileAndHttpException.apply(元のException)`のようなコードに展開されるので、case classのフィールドは1つ＆Throwableのような元の例外が入れられるような型でないと行けないという制約があります。

省略記法なのである程度便利であれば柔軟性はそこそこでもよいかなと考えています(´･_･`)

before

```
case class DatabaseAndHttpException(m: String) extends RootException
object DatabaseAndHttpException {
  implicit val databaseException = new :->[DatabaseException, DatabaseAndHttpException] {
    def cast(a: DatabaseException): DatabaseAndHttpException =
      DatabaseAndHttpException(s"database: ${a.m}")
  }

  implicit val httpException = new :->[HttpException, DatabaseAndHttpException] {
    def cast(a: HttpException): DatabaseAndHttpException =
      DatabaseAndHttpException(s"http: ${a.m}")
  }
}
```

after

```
case class FileAndHttpException(cause: Throwable) extends RootException
object FileAndHttpException {
  implicit val fileException = Transform.castable[FileException, FileAndHttpException]
  implicit val httpException = Transform.castable[HttpException, FileAndHttpException]
}
```
