### PR TITLE
:->に変位指定を追加

### DIFF
--- a/src/main/scala/utils/Transform.scala
+++ b/src/main/scala/utils/Transform.scala
@@ -1,6 +1,6 @@
 package utils
 
-trait :->[A, B] {
+trait :->[-A, +B] {
   def cast(a: A): B
 }
 
@@ -9,3 +9,4 @@ object :-> {
     def cast(a: A): B = a
   }
 }
+


### PR DESCRIPTION
A :-> Bを定義するだけで
`A <: superA`である`superA`を使った`superA :-> B`や
`B >: childB`を使った`A :-> childB`も一緒に定義することができます。
